### PR TITLE
Fix error 500 when starting daemon before network was available

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -312,6 +312,11 @@ async def cleanup():
   await c.client.disconnect()
   print("OK!")
 
+@app.before_request
+async def conn_check():
+  if not c.client.is_connected():
+    print("Not connected, reconnecting...")
+    await startup()
 
 # #################### Init
 async def main():


### PR DESCRIPTION
When using this as a daemon on a laptop, sometimes WiFi becomes available too late and Telethon fails to connect.

This change will check if Telethon is connected before attempting to serve a feed.